### PR TITLE
Fixing getCodec so we can use gzip for compression

### DIFF
--- a/lib/codec/index.js
+++ b/lib/codec/index.js
@@ -13,7 +13,7 @@ var codecs = [
 ];
 
 function getCodec(attributes) {
-    return codecs[attributes & 2] || null;
+    return codecs[parseInt(attributes, 10)] || null;
 }
 
 module.exports = getCodec;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafka-node--light",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "kafka.js",
   "dependencies": {
     "async": ">0.9 <2.0",


### PR DESCRIPTION
Using the actual attribute itself when trying to choose a codec for compression. The previous implementation would never allow gzip to be chosen due to the bitwise operator. With this change, you can set attribute to 1 so that gzip compression/decompression can take place.
